### PR TITLE
v4.7.1 - move expo- dependencies to peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 ## Statsig React Native Expo SDK
 
-The Statsig SDK for React Native with Expo. If you're looking to use Statsig for React Native without Expo, try [https://github.com/statsig-io/react-native](https://github.com/statsig-io/react-native). If you need a SDK for another language or server environment, check out our [other SDKs](https://docs.statsig.com/#sdks).
+> [!IMPORTANT]
+> This version of the SDK is now in maintainance mode and will only receive bug fixes.
+> All new features will be added to the [@statsig/js-client and @statsig/expo-bindings packages](https://github.com/statsig-io/js-client-monorepo).
+> Users of the `statsig-react-native-expo` npm package should migrate to the `@statsig/js-client` and `@statsig/expo-bindings` packages by 1/31/2025 - see this [guide](https://docs.statsig.com/client/javascript-sdk/expo?ref=gh_rne).
 
-Statsig helps you move faster with Feature Gates (Feature Flags) and Dynamic Configs. It also allows you to run A/B tests to validate your new features and understand their impact on your KPIs. If you're new to Statsig, create an account at [statsig.com](https://www.statsig.com).
+The Statsig SDK for React Native with Expo. If you're looking to use Statsig for React Native without Expo, try [https://github.com/statsig-io/react-native](https://github.com/statsig-io/react-native). If you need a SDK for another language or server environment, check out our [other SDKs](https://docs.statsig.com/#sdks?ref=gh_rne).
+
+Statsig helps you move faster with Feature Gates (Feature Flags) and Dynamic Configs. It also allows you to run A/B tests to validate your new features and understand their impact on your KPIs. If you're new to Statsig, create an account at [statsig.com](https://www.statsig.com?ref=gh_rne).
 
 ## Getting Started
 
-Check out our [SDK docs](https://docs.statsig.com/client/reactNativeExpoSDK) to get started.
+Check out our [SDK docs](https://docs.statsig.com/client/reactNativeExpoSDK?ref=gh_rne) to get started.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "js-sha256": "^0.9.0",
-        "statsig-react": "1.38.0",
+        "statsig-react": "2.0.0",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -19,11 +19,11 @@
         "typescript": "^5.3.0"
       },
       "peerDependencies": {
-        "@react-native-async-storage/async-storage": "1.21.0",
-        "expo-constants": "~15.4.5",
-        "expo-device": "^5.2.1",
+        "@react-native-async-storage/async-storage": "^1.15.0",
+        "expo-constants": "^13.0.0 || 14.0.0 || ^15.0.0",
+        "expo-device": "4.0.0 || ^5.2.1",
         "react-native": ">=0.69.0",
-        "react-native-get-random-values": "~1.8.0"
+        "react-native-get-random-values": "^1.8.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -11010,12 +11010,12 @@
       }
     },
     "node_modules/statsig-js": {
-      "version": "4.51.0",
-      "resolved": "https://registry.npmjs.org/statsig-js/-/statsig-js-4.51.0.tgz",
-      "integrity": "sha512-EbCWfrDHwqntUA1zK4nlnjLMBV+5OAHaZCqmjiw2vOFFp0YTLNNj205lkhP3hbyfNEyPldzJ+ooYwLSifHvAMA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/statsig-js/-/statsig-js-5.0.0.tgz",
+      "integrity": "sha512-Xhi0IzsOdIN2V4jfSrHmeGf+KQrNar79CynE7y3dBuTXpXpWc9ymB67CzcbiY+melJ337+NuNjvBdrrRw2cAhQ==",
       "dependencies": {
         "js-sha256": "^0.11.0",
-        "uuid": "^8.3.2"
+        "uuid": "^9.0.1"
       }
     },
     "node_modules/statsig-js/node_modules/js-sha256": {
@@ -11023,12 +11023,24 @@
       "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.0.tgz",
       "integrity": "sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q=="
     },
+    "node_modules/statsig-js/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/statsig-react": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/statsig-react/-/statsig-react-1.38.0.tgz",
-      "integrity": "sha512-XaeCfbmvVJsOleB58zYHrXL0UVNVmgEit1rdahc72S+TOxNiuHTvpk/IXf6M8/uKD8psNDiLgVuCGUTNJGBMyA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/statsig-react/-/statsig-react-2.0.0.tgz",
+      "integrity": "sha512-KnM8bxjGhKC/0nr+tUzSppuNRQbUH8OVGVeNX5C8Rjoyu+N+OTl2I/ufIHQFEzRCmrsNpLmniPLFbdY2T544rA==",
       "dependencies": {
-        "statsig-js": "4.51.0"
+        "statsig-js": "5.0.0"
       },
       "peerDependencies": {
         "react": "^16.6.3 || ^17.0.0 || ^18.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "statsig-react-native-expo",
-  "version": "4.7.0",
+  "version": "4.7.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "statsig-react-native-expo",
-      "version": "4.7.0",
+      "version": "4.7.0-beta.1",
       "license": "ISC",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "^1.15.0",
         "js-sha256": "^0.9.0",
+        "react-native-get-random-values": "^1.8.0",
         "statsig-react": "2.0.0",
         "uuid": "^8.3.2"
       },
@@ -19,11 +21,9 @@
         "typescript": "^5.3.0"
       },
       "peerDependencies": {
-        "@react-native-async-storage/async-storage": "^1.15.0",
         "expo-constants": "^13.0.0 || 14.0.0 || ^15.0.0",
         "expo-device": "4.0.0 || ^5.2.1",
-        "react-native": ">=0.69.0",
-        "react-native-get-random-values": "^1.8.0"
+        "react-native": ">=0.69.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3265,7 +3265,6 @@
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.21.0.tgz",
       "integrity": "sha512-JL0w36KuFHFCvnbOXRekqVAUplmOyT/OuCQkogo6X98MtpSaJOKEAeZnYO8JB0U/RIEixZaGI5px73YbRm/oag==",
-      "peer": true,
       "dependencies": {
         "merge-options": "^3.0.4"
       },
@@ -6808,8 +6807,7 @@
     "node_modules/fast-base64-decode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
-      "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==",
-      "peer": true
+      "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -7642,7 +7640,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8660,7 +8657,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
       "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-      "peer": true,
       "dependencies": {
         "is-plain-obj": "^2.1.0"
       },
@@ -10285,7 +10281,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.8.0.tgz",
       "integrity": "sha512-H/zghhun0T+UIJLmig3+ZuBCvF66rdbiWUfRSNS6kv5oDSpa1ZiVyvRWtuPesQpT8dXj+Bv7WJRQOUP+5TB1sA==",
-      "peer": true,
       "dependencies": {
         "fast-base64-decode": "^1.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,7 @@
       "version": "4.7.0",
       "license": "ISC",
       "dependencies": {
-        "@react-native-async-storage/async-storage": "1.21.0",
-        "expo-constants": "~15.4.5",
-        "expo-device": "^5.2.1",
         "js-sha256": "^0.9.0",
-        "react-native-get-random-values": "~1.8.0",
         "statsig-react": "1.38.0",
         "uuid": "^8.3.2"
       },
@@ -23,7 +19,11 @@
         "typescript": "^5.3.0"
       },
       "peerDependencies": {
-        "react-native": ">=0.69.0"
+        "@react-native-async-storage/async-storage": "1.21.0",
+        "expo-constants": "~15.4.5",
+        "expo-device": "^5.2.1",
+        "react-native": ">=0.69.0",
+        "react-native-get-random-values": "~1.8.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2347,6 +2347,7 @@
       "version": "8.5.4",
       "resolved": "https://registry.npmjs.org/@expo/config/-/config-8.5.4.tgz",
       "integrity": "sha512-ggOLJPHGzJSJHVBC1LzwXwR6qUn8Mw7hkc5zEKRIdhFRuIQ6s2FE4eOvP87LrNfDF7eZGa6tJQYsiHSmZKG+8Q==",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
         "@expo/config-plugins": "~7.8.2",
@@ -2365,6 +2366,7 @@
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-7.8.4.tgz",
       "integrity": "sha512-hv03HYxb/5kX8Gxv/BTI8TLc9L06WzqAfHRRXdbar4zkLcP2oTzvsLEF4/L/TIpD3rsnYa0KU42d0gWRxzPCJg==",
+      "peer": true,
       "dependencies": {
         "@expo/config-types": "^50.0.0-alpha.1",
         "@expo/fingerprint": "^0.6.0",
@@ -2389,6 +2391,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2407,12 +2410,14 @@
     "node_modules/@expo/config-types": {
       "version": "50.0.0",
       "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-50.0.0.tgz",
-      "integrity": "sha512-0kkhIwXRT6EdFDwn+zTg9R2MZIAEYGn1MVkyRohAd+C9cXOb5RA8WLQi7vuxKF9m1SMtNAUrf0pO+ENK0+/KSw=="
+      "integrity": "sha512-0kkhIwXRT6EdFDwn+zTg9R2MZIAEYGn1MVkyRohAd+C9cXOb5RA8WLQi7vuxKF9m1SMtNAUrf0pO+ENK0+/KSw==",
+      "peer": true
     },
     "node_modules/@expo/config/node_modules/glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2432,6 +2437,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -2443,6 +2449,7 @@
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
       "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2456,7 +2463,8 @@
     "node_modules/@expo/config/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "peer": true
     },
     "node_modules/@expo/devcert": {
       "version": "1.1.0",
@@ -2505,6 +2513,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.6.0.tgz",
       "integrity": "sha512-KfpoVRTMwMNJ/Cf5o+Ou8M/Y0EGSTqK+rbi70M2Y0K2qgWNfMJ1gm6sYO9uc8lcTr7YSYM1Rme3dk7QXhpScNA==",
+      "peer": true,
       "dependencies": {
         "@expo/spawn-async": "^1.5.0",
         "chalk": "^4.1.2",
@@ -2650,6 +2659,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.3.0.tgz",
       "integrity": "sha512-yROUeXJXR5goagB8c3muFLCzLmdGOvoPpR5yDNaXrnTp4euNykr9yW0wWhJx4YVRTNOPtGBnEbbJBW+a9q+S6g==",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
         "json5": "^2.2.2",
@@ -2837,6 +2847,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.1.0.tgz",
       "integrity": "sha512-xWD+8vIFif0wKyuqe3fmnmnSouXYucciZXFzS0ZD5OV9eSAS1RGQI5FaGGJ6zxJ4mpdy/4QzbLdBjnYE5vxA0g==",
+      "peer": true,
       "dependencies": {
         "@xmldom/xmldom": "~0.7.7",
         "base64-js": "^1.2.3",
@@ -2954,12 +2965,14 @@
     "node_modules/@expo/sdk-runtime-versions": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@expo/sdk-runtime-versions/-/sdk-runtime-versions-1.0.0.tgz",
-      "integrity": "sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ=="
+      "integrity": "sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==",
+      "peer": true
     },
     "node_modules/@expo/spawn-async": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.5.0.tgz",
       "integrity": "sha512-LB7jWkqrHo+5fJHNrLAFdimuSXQ2MQ4lA7SQW5bf/HbsXuV2VrT/jN/M8f/KoWt0uJMGN4k/j7Opx4AvOOxSew==",
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^6.0.5"
       },
@@ -3252,6 +3265,7 @@
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.21.0.tgz",
       "integrity": "sha512-JL0w36KuFHFCvnbOXRekqVAUplmOyT/OuCQkogo6X98MtpSaJOKEAeZnYO8JB0U/RIEixZaGI5px73YbRm/oag==",
+      "peer": true,
       "dependencies": {
         "merge-options": "^3.0.4"
       },
@@ -4875,7 +4889,8 @@
     "node_modules/@react-native/normalize-color": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@react-native/normalize-color/-/normalize-color-2.1.0.tgz",
-      "integrity": "sha512-Z1jQI2NpdFJCVgpY+8Dq/Bt3d+YUi1928Q+/CZm/oh66fzM0RUl54vvuXlPJKybH4pdCZey1eDTPaLHkMPNgWA=="
+      "integrity": "sha512-Z1jQI2NpdFJCVgpY+8Dq/Bt3d+YUi1928Q+/CZm/oh66fzM0RUl54vvuXlPJKybH4pdCZey1eDTPaLHkMPNgWA==",
+      "peer": true
     },
     "node_modules/@react-native/normalize-colors": {
       "version": "0.73.2",
@@ -5039,6 +5054,7 @@
       "version": "0.7.13",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
       "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -5157,7 +5173,8 @@
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "peer": true
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -5525,6 +5542,7 @@
       "version": "1.6.52",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
       "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -5562,6 +5580,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
       "integrity": "sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==",
+      "peer": true,
       "dependencies": {
         "stream-buffers": "2.2.x"
       }
@@ -6198,6 +6217,7 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "peer": true,
       "dependencies": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -6213,6 +6233,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "peer": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -6672,6 +6693,7 @@
       "version": "15.4.5",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-15.4.5.tgz",
       "integrity": "sha512-1pVVjwk733hbbIjtQcvUFCme540v4gFemdNlaxM2UXKbfRCOh2hzgKN5joHMOysoXQe736TTUrRj7UaZI5Yyhg==",
+      "peer": true,
       "dependencies": {
         "@expo/config": "~8.5.0"
       },
@@ -6683,6 +6705,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-5.9.3.tgz",
       "integrity": "sha512-azH5rz8krDZUJb/arqkcA6oZGaX2T5s4aaXIMFsDDzvq8TW0CttZZy2HFp6itmFdiKGdRpFX3/Gj0n6ZmPoJ/w==",
+      "peer": true,
       "dependencies": {
         "ua-parser-js": "^0.7.33"
       },
@@ -6785,7 +6808,8 @@
     "node_modules/fast-base64-decode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
-      "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q=="
+      "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==",
+      "peer": true
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -7120,6 +7144,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/getenv/-/getenv-1.0.0.tgz",
       "integrity": "sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg==",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7617,6 +7642,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8278,7 +8304,8 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "peer": true
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -8633,6 +8660,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
       "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "peer": true,
       "dependencies": {
         "is-plain-obj": "^2.1.0"
       },
@@ -9232,6 +9260,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "peer": true,
       "dependencies": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -9288,7 +9317,8 @@
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "peer": true
     },
     "node_modules/nocache": {
       "version": "3.0.4",
@@ -9779,6 +9809,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -9901,6 +9932,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
       "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "peer": true,
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
         "base64-js": "^1.5.1",
@@ -9914,6 +9946,7 @@
       "version": "0.8.10",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
       "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -9922,6 +9955,7 @@
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
       "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "peer": true,
       "engines": {
         "node": ">=8.0"
       }
@@ -10251,6 +10285,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.8.0.tgz",
       "integrity": "sha512-H/zghhun0T+UIJLmig3+ZuBCvF66rdbiWUfRSNS6kv5oDSpa1ZiVyvRWtuPesQpT8dXj+Bv7WJRQOUP+5TB1sA==",
+      "peer": true,
       "dependencies": {
         "fast-base64-decode": "^1.0.0"
       },
@@ -10451,6 +10486,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10503,6 +10539,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -10589,7 +10626,8 @@
     "node_modules/sax": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
-      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
+      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
+      "peer": true
     },
     "node_modules/scheduler": {
       "version": "0.24.0-canary-efb381bbf-20230505",
@@ -10753,6 +10791,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "peer": true,
       "dependencies": {
         "shebang-regex": "^1.0.0"
       },
@@ -10764,6 +10803,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10785,6 +10825,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.3.1.tgz",
       "integrity": "sha512-iMSw5i0XseMnrhtIzRb7XpQEXepa9xhWxGUojHBL43SIpQuDQkh3Wpy67ZbDzZVr6EKxvwVChnVpdl8hEVLDiw==",
+      "peer": true,
       "dependencies": {
         "bplist-creator": "0.1.0",
         "bplist-parser": "0.3.1",
@@ -10795,6 +10836,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.1.tgz",
       "integrity": "sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA==",
+      "peer": true,
       "dependencies": {
         "big-integer": "1.6.x"
       },
@@ -10856,6 +10898,7 @@
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
       "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -11003,6 +11046,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
       "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==",
+      "peer": true,
       "engines": {
         "node": ">= 0.10.0"
       }
@@ -11107,6 +11151,7 @@
       "version": "3.34.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.34.0.tgz",
       "integrity": "sha512-70/LQEZ07TEcxiU2dz51FKaE6hCTWC6vr7FOk3Gr0U60C3shtAN+H+BFr9XlYe5xqf3RA8nrc+VIwzCfnxuXJw==",
+      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
@@ -11128,6 +11173,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -11136,6 +11182,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -11357,6 +11404,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "peer": true,
       "dependencies": {
         "any-promise": "^1.0.0"
       }
@@ -11365,6 +11413,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "peer": true,
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
       },
@@ -11456,7 +11505,8 @@
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "peer": true
     },
     "node_modules/tslib": {
       "version": "2.6.2",
@@ -11514,6 +11564,7 @@
           "url": "https://github.com/sponsors/faisalman"
         }
       ],
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -11751,6 +11802,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -11836,6 +11888,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/xcode/-/xcode-3.0.1.tgz",
       "integrity": "sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==",
+      "peer": true,
       "dependencies": {
         "simple-plist": "^1.1.0",
         "uuid": "^7.0.3"
@@ -11848,6 +11901,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
       "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -11856,6 +11910,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
       "integrity": "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==",
+      "peer": true,
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -11868,6 +11923,7 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -11876,6 +11932,7 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-14.0.0.tgz",
       "integrity": "sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg==",
+      "peer": true,
       "engines": {
         "node": ">=8.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.7.0-beta.1",
       "license": "ISC",
       "dependencies": {
-        "@react-native-async-storage/async-storage": "^1.15.0",
+        "@react-native-async-storage/async-storage": "^1.21.0",
         "js-sha256": "^0.9.0",
         "react-native-get-random-values": "^1.8.0",
         "statsig-react": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "statsig-react-native-expo",
-  "version": "4.7.0-beta.1",
+  "version": "4.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "statsig-react-native-expo",
-      "version": "4.7.0-beta.1",
+      "version": "4.7.1",
       "license": "ISC",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^1.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statsig-react-native-expo",
-  "version": "4.7.0-beta.1",
+  "version": "4.7.1",
   "description": "Statsig SDK to be used in React Native Expo applications",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "js-sha256": "^0.9.0",
     "statsig-react": "2.0.0",
     "uuid": "^8.3.2",
-    "@react-native-async-storage/async-storage": "^1.15.0",
+    "@react-native-async-storage/async-storage": "^1.21.0",
     "react-native-get-random-values": "^1.8.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,15 +26,15 @@
   "homepage": "https://www.statsig.com",
   "dependencies": {
     "js-sha256": "^0.9.0",
-    "statsig-react": "1.38.0",
+    "statsig-react": "2.0.0",
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
     "react-native": ">=0.69.0",
-    "@react-native-async-storage/async-storage": "1.21.0",
-    "react-native-get-random-values": "~1.8.0",
-    "expo-constants": "~15.4.5",
-    "expo-device": "^5.2.1"
+    "@react-native-async-storage/async-storage": "^1.15.0",
+    "react-native-get-random-values": "^1.8.0",
+    "expo-constants": "^13.0.0 || 14.0.0 || ^15.0.0",
+    "expo-device": "4.0.0 || ^5.2.1"
   },
   "devDependencies": {
     "@types/react": "~18.2.45",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statsig-react-native-expo",
-  "version": "4.7.0",
+  "version": "4.7.0-beta.1",
   "description": "Statsig SDK to be used in React Native Expo applications",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -27,12 +27,12 @@
   "dependencies": {
     "js-sha256": "^0.9.0",
     "statsig-react": "2.0.0",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "@react-native-async-storage/async-storage": "^1.15.0",
+    "react-native-get-random-values": "^1.8.0"
   },
   "peerDependencies": {
     "react-native": ">=0.69.0",
-    "@react-native-async-storage/async-storage": "^1.15.0",
-    "react-native-get-random-values": "^1.8.0",
     "expo-constants": "^13.0.0 || 14.0.0 || ^15.0.0",
     "expo-device": "4.0.0 || ^5.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -25,16 +25,16 @@
   ],
   "homepage": "https://www.statsig.com",
   "dependencies": {
-    "@react-native-async-storage/async-storage": "1.21.0",
-    "expo-constants": "~15.4.5",
-    "expo-device": "^5.2.1",
     "js-sha256": "^0.9.0",
-    "react-native-get-random-values": "~1.8.0",
     "statsig-react": "1.38.0",
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "react-native": ">=0.69.0"
+    "react-native": ">=0.69.0",
+    "@react-native-async-storage/async-storage": "1.21.0",
+    "react-native-get-random-values": "~1.8.0",
+    "expo-constants": "~15.4.5",
+    "expo-device": "^5.2.1"
   },
   "devDependencies": {
     "@types/react": "~18.2.45",


### PR DESCRIPTION
expo-constants and expo-device were incorrectly listed under `dependencies` of the package, when they are `peer dependencies` that we should inherit from the hosting app

also added a notice on maintainance for this package as we move to @statsig/js-client and expo/react bindings